### PR TITLE
Add configuration parameters

### DIFF
--- a/lib/volie/client/campaign_customer.rb
+++ b/lib/volie/client/campaign_customer.rb
@@ -25,7 +25,7 @@ module Volie
         response.is_a?(Hash) && response['errors'] == false
       end
 
-      def set_customer_vehicle(make:, model:, year:, trim:, vin:)
+      def set_customer_vehicle(make:, model:, year:, trim:, vin:, configuration: nil)
         self.class.post(
           path: 'set_customer_vehicle',
           parameters: {
@@ -35,13 +35,14 @@ module Volie
             vehicle_model_year: year,
             vehicle_trim: trim,
             vehicle_vin: vin
-          }
+          },
+          configuration: configuration
         )
       end
 
       class << self
-        def create(attributes)
-          new post(path: 'enroll_campaign_customer', parameters: attributes)
+        def create(attributes, configuration = nil)
+          new post(path: 'enroll_campaign_customer', parameters: attributes, configuration: configuration)
         end
       end
     end

--- a/lib/volie/client/configuration.rb
+++ b/lib/volie/client/configuration.rb
@@ -7,8 +7,6 @@ module Volie
   module Client
     # This class is responsible for holding Authentication information for the Volie API
     class Configuration
-      include Singleton
-
       attr_accessor :access_key, :secret_key
 
       def initialize

--- a/lib/volie/client/customer.rb
+++ b/lib/volie/client/customer.rb
@@ -26,8 +26,8 @@ module Volie
         end
       end
 
-      def update(attributes = {})
-        self.class.new self.class.post(path: 'update_customer', parameters: @attributes.merge(attributes))
+      def update(attributes = {}, configuration = nil)
+        self.class.new self.class.post(path: 'update_customer', parameters: @attributes.merge(attributes), configuration: configuration)
       end
 
       def destroy
@@ -40,8 +40,8 @@ module Volie
       end
 
       class << self
-        def find_or_create_by(attributes)
-          new post(path: 'match_or_create_customer', parameters: attributes)
+        def find_or_create_by(attributes, configuration = nil)
+          new post(path: 'match_or_create_customer', parameters: attributes, configuration: configuration)
         end
       end
     end

--- a/lib/volie/client/expire_customer.rb
+++ b/lib/volie/client/expire_customer.rb
@@ -9,8 +9,8 @@ module Volie
       # define_rest_actions :expire_customer, except: :create
 
       class << self
-        def remove(attributes)
-          new post(path: 'remove_customer_from_queue', parameters: attributes)
+        def remove(attributes, congfiguration = nil)
+          new post(path: 'remove_customer_from_queue', parameters: attributes, configuration: configuration)
         end
       end
     end

--- a/lib/volie/client/resource.rb
+++ b/lib/volie/client/resource.rb
@@ -61,10 +61,10 @@ module Volie
       end
 
       class << self
-        def auth_params
+        def auth_params(configuration)
           {
-            access_key: Configuration.instance.access_key,
-            secret_key: Configuration.instance.secret_key
+            access_key: configuration.access_key,
+            secret_key: configuration.secret_key
           }
         end
 
@@ -79,14 +79,15 @@ module Volie
           MultiJson.load(response.body.to_s)
         end
 
-        def post(path:, parameters:)
+        def post(path:, parameters:, configuration: nil)
+          configuration = Configuration.new if configuration.nil?
           validate_configured!
           handle_response HTTP.post(request_url(path: path), params: parameters.merge(auth_params))
         end
 
-        def validate_configured!
+        def validate_configured!(configuration = nil)
           error_message = 'Volie must be configured with a valid API access key and secret key before use.'
-          raise ::Volie::Client::Error, error_message unless Configuration.instance.valid?
+          raise ::Volie::Client::Error, error_message unless configuration.valid?
         end
 
         def should_define_rest_action?(action, options)
@@ -98,7 +99,7 @@ module Volie
           )
         end
 
-        def define_rest_actions(resource_name, opts = {})
+        def define_rest_actions(resource_name, opts = {}, configuration = nil)
           params = opts.with_indifferent_access
 
           if should_define_rest_action?(:list, params)

--- a/lib/volie/client/resource.rb
+++ b/lib/volie/client/resource.rb
@@ -82,7 +82,7 @@ module Volie
         def post(path:, parameters:, configuration: nil)
           configuration = Configuration.new if configuration.nil?
           validate_configured!
-          handle_response HTTP.post(request_url(path: path), params: parameters.merge(auth_params))
+          handle_response HTTP.post(request_url(path: path), params: parameters.merge(auth_params), configuration: configuration)
         end
 
         def validate_configured!(configuration = nil)
@@ -104,7 +104,7 @@ module Volie
 
           if should_define_rest_action?(:list, params)
             define_singleton_method :list do |options = {}|
-              post(path: "get_#{resource_name.to_s.pluralize}", parameters: options).map(&method(:new))
+              post(configuration, path: "get_#{resource_name.to_s.pluralize}", parameters: options).map(&method(:new))
             end
 
             define_singleton_method :list_all_the_things do |options = {}, &block|
@@ -120,17 +120,17 @@ module Volie
             end
           end
 
-          if should_define_rest_action?(:find, params)
+          if should_define_rest_action?(:find, params, configuration)
             define_singleton_method :find do |resource_key|
-              new post(path: "find_#{resource_name}", parameters: { "#{resource_name}_key" => resource_key })
+              new post(path: "find_#{resource_name}", parameters: { "#{resource_name}_key" => resource_key }, configuration: configuration)
             end
           end
 
           # Deliberately not using a guard clause here to match the style of the rest of the method
           # rubocop:disable Style/GuardClause
-          if should_define_rest_action?(:create, params)
+          if should_define_rest_action?(:create, params, configuration)
             define_singleton_method :create do |attributes|
-              new post(path: "create_#{resource_name}", parameters: attributes)
+              new post(path: "create_#{resource_name}", parameters: attributes, configuration: configuration)
             end
           end
           # rubocop:enable Style/GuardClause

--- a/lib/volie/client/sale.rb
+++ b/lib/volie/client/sale.rb
@@ -20,8 +20,8 @@ module Volie
                       vehicle_trim vehicle_type vehicle_vin].freeze
 
       class << self
-        def find_or_create_by(attributes)
-          new post(path: 'match_or_create_sale', parameters: attributes)
+        def find_or_create_by(attributes, configuration)
+          new post(path: 'match_or_create_sale', parameters: attributes, configuration: configuration)
         end
       end
     end

--- a/lib/volie/client/service.rb
+++ b/lib/volie/client/service.rb
@@ -33,8 +33,8 @@ module Volie
       ].freeze
 
       class << self
-        def find_or_create_by(attributes)
-          result = post(path: 'match_or_create_service', parameters: attributes)
+        def find_or_create_by(attributes, configuration = nil)
+          result = post(path: 'match_or_create_service', parameters: attributes, configuration: configuration)
           result[:service_lines] ||= []
           result[:service_lines] = result[:service_lines].map(&ServiceLine.method(:new))
           new result

--- a/lib/volie/version.rb
+++ b/lib/volie/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Volie
-  VERSION = '0.3.5'
+  VERSION = '0.3.6'
 end

--- a/test/volie/client/configuration_test.rb
+++ b/test/volie/client/configuration_test.rb
@@ -5,44 +5,44 @@ require 'test_helper'
 module Volie
   module Client
     class ConfigurationTest < ::Minitest::Test
-      def configure_client(configuration = nil)
-        configuration.configure(access_key: configuration.access_key, secret_key: configuration.secret_key)
+      def configure_client(access_key, secret_key)
+        Configuration.instance.configure(access_key: access_key, secret_key: secret_key)
       end
 
-      def test_can_successfully_configure_the_client(configuration = nil)
+      def test_can_successfully_configure_the_client
         self.configure_client('test-access-key', 'test-secret-key')
-        assert_equal 'test-access-key', configuration.access_key
-        assert_equal 'test-secret-key', configuration.secret_key
+        assert_equal 'test-access-key', Configuration.instance.access_key
+        assert_equal 'test-secret-key', Configuration.instance.secret_key
       end
 
-      def test_can_successfully_clear_configuration(configuration = nil)
+      def test_can_successfully_clear_configuration
         self.configure_client('test-access', 'test-secret')
-        refute_nil configuration.access_key
-        refute_nil configuration.secret_key
-        configuration.clear!
-        assert_nil configuration.access_key
-        assert_nil configuration.secret_key
+        refute_nil Configuration.instance.access_key
+        refute_nil Configuration.instance.secret_key
+        Configuration.instance.clear!
+        assert_nil Configuration.instance.access_key
+        assert_nil Configuration.instance.secret_key
       end
 
-      def test_configuration_with_no_access_key_or_secret_key_is_invalid(configuration = nil)
-        refute configuration.valid?
+      def test_configuration_with_no_access_key_or_secret_key_is_invalid
+        refute Configuration.instance.valid?
       end
 
-      def test_if_no_configuration_is_provided_then_configuration_from_environment_is_used(configuration = nil)
+      def test_if_no_configuration_is_provided_then_configuration_from_environment_is_used
         ENV['VOLIE_ACCESS_KEY'] = 'testing-env-access'
         ENV['VOLIE_SECRET_KEY'] = 'testing-env-secret'
         # unless this is the first test that runs, there's no way to NOT have the
         # singleton configuration class already defined by this point. So we'll
         # manually call the configure from environment method and then confirm
         # that that method is called by the initialize method
-        configuration.configure_from_environment
-        assert_equal 'testing-env-access', configuration.access_key
-        assert_equal 'testing-env-secret', configuration.secret_key
+        Configuration.instance.configure_from_environment
+        assert_equal 'testing-env-access', Configuration.instance.access_key
+        assert_equal 'testing-env-secret', Configuration.instance.secret_key
       end
 
-      def test_valid_succeeds_with_valid_configuration(configuration = nil)
+      def test_valid_succeeds_with_valid_configuration
         self.configure_client('test-access-key', 'test-secret-key')
-        assert configuration.valid?
+        assert Configuration.instance.valid?
       end
     end
   end

--- a/test/volie/client/configuration_test.rb
+++ b/test/volie/client/configuration_test.rb
@@ -5,44 +5,44 @@ require 'test_helper'
 module Volie
   module Client
     class ConfigurationTest < ::Minitest::Test
-      def configure_client(access_key, secret_key)
-        Configuration.instance.configure(access_key: access_key, secret_key: secret_key)
+      def configure_client(configuration = nil)
+        configuration.configure(access_key: configuration.access_key, secret_key: configuration.secret_key)
       end
 
-      def test_can_successfully_configure_the_client
+      def test_can_successfully_configure_the_client(configuration = nil)
         self.configure_client('test-access-key', 'test-secret-key')
-        assert_equal 'test-access-key', Configuration.instance.access_key
-        assert_equal 'test-secret-key', Configuration.instance.secret_key
+        assert_equal 'test-access-key', configuration.access_key
+        assert_equal 'test-secret-key', configuration.secret_key
       end
 
-      def test_can_successfully_clear_configuration
+      def test_can_successfully_clear_configuration(configuration = nil)
         self.configure_client('test-access', 'test-secret')
-        refute_nil Configuration.instance.access_key
-        refute_nil Configuration.instance.secret_key
-        Configuration.instance.clear!
-        assert_nil Configuration.instance.access_key
-        assert_nil Configuration.instance.secret_key
+        refute_nil configuration.access_key
+        refute_nil configuration.secret_key
+        configuration.clear!
+        assert_nil configuration.access_key
+        assert_nil configuration.secret_key
       end
 
-      def test_configuration_with_no_access_key_or_secret_key_is_invalid
-        refute Configuration.instance.valid?
+      def test_configuration_with_no_access_key_or_secret_key_is_invalid(configuration = nil)
+        refute configuration.valid?
       end
 
-      def test_if_no_configuration_is_provided_then_configuration_from_environment_is_used
+      def test_if_no_configuration_is_provided_then_configuration_from_environment_is_used(configuration = nil)
         ENV['VOLIE_ACCESS_KEY'] = 'testing-env-access'
         ENV['VOLIE_SECRET_KEY'] = 'testing-env-secret'
         # unless this is the first test that runs, there's no way to NOT have the
         # singleton configuration class already defined by this point. So we'll
         # manually call the configure from environment method and then confirm
         # that that method is called by the initialize method
-        Configuration.instance.configure_from_environment
-        assert_equal 'testing-env-access', Configuration.instance.access_key
-        assert_equal 'testing-env-secret', Configuration.instance.secret_key
+        configuration.configure_from_environment
+        assert_equal 'testing-env-access', configuration.access_key
+        assert_equal 'testing-env-secret', configuration.secret_key
       end
 
-      def test_valid_succeeds_with_valid_configuration
+      def test_valid_succeeds_with_valid_configuration(configuration = nil)
         self.configure_client('test-access-key', 'test-secret-key')
-        assert Configuration.instance.valid?
+        assert configuration.valid?
       end
     end
   end


### PR DESCRIPTION
Adds the ability to take in parameters in all the functions that make post requests to the volie api. Not complete, making PR to test functionality.

Updating version to v0.3.6